### PR TITLE
Moved TUMOR_TYPE from data_patient to data_sample

### DIFF
--- a/public/kirp_tcga.tar.gz
+++ b/public/kirp_tcga.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:96c4df7046c78793b7b0a6b583839bb9a73360b78ff1d8cfd2179d6ef7ea58cd
-size 87746272
+oid sha256:20c1bc90c68b1557c74ca39560bb08a98375149e388d47fbcf821e3ab8e4f087
+size 87801626

--- a/public/tgct_tcga.tar.gz
+++ b/public/tgct_tcga.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b57eb554f22f503b914dcc83f7b21fdb5542140534c34cf0f2c399b4a903e30e
-size 48246379
+oid sha256:27e13c1ce2c0f0cf8b7b2a8d22806c351b32d6f13333d74cc6fb672519128e97
+size 48280115


### PR DESCRIPTION
Hi Zack,

In this PR I moved the TUMOR_TYPE attribute from the clinical data patient to the sample file, to fix an issue in #11. This was only necessary for kirp and tgct; in the other studies the attribute is not present. Now these studies are successfully validated when using the latest hotfix + fixes from #PR1868 en and #1866. 

What I've done is:
1. Create new column in data_sample with [Not Available]
2. Fill the primary tumor sample rows in data_sample with the values from data_patient.
3. Make sure that the header (including the meta data in the first 4 lines) is also transferred.
4. Remove the column from data_patient.

If you'd like to see the code (written in R), I'd be happy to share it.

Kind regards,
Sander, The Hyve


